### PR TITLE
got node only version working. it was a single typo in the server.js …

### DIFF
--- a/Dockerfile.nodeonly
+++ b/Dockerfile.nodeonly
@@ -1,0 +1,12 @@
+FROM node:lts-alpine3.21 AS base
+
+RUN mkdir /SotN-Randomizer
+WORKDIR /SotN-Randomizer
+COPY /SotN-Randomizer/ /SotN-Randomizer
+COPY server.js /SotN-Randomizer
+
+RUN npm install connect serve-static
+RUN npm install
+
+EXPOSE 8080
+ENTRYPOINT ["node", "server.js"]

--- a/README.md
+++ b/README.md
@@ -8,8 +8,44 @@ It is mapped to localhost:30000 currently.
 
 It's currently set up to use the randomizer app as a submodule. You may have to run the recursive submodule commands to clone all the requirements for the container, we will find out in further testing.
 
+## Dev Notes
+
 Commands:
+
+For the master branch's nginx workflow:
 
 `docker compose build`
 
 `docker compose up -d`
+
+To stop:
+
+`docker compose down`
+
+If you want to work with the node only version (no NGINX as a server):
+
+`docker compose build -f docker-compose-nodeonly.yml`
+
+`docker compose -f docker-compose-nodeonly.yml up -d`
+
+To stop:
+
+`docker compose -f docker-compose-nodeonly.yml down`
+
+## Why Two Versions?
+
+This was an interesting exercise to get things to work for us. It was useful to get a bit more familiar with node, and to learn a proper nginx deployment.
+
+### Node Only
+
+As an academic exercise for two nerds who are not familiar with node, the `nodeonly` version helped us get familiar with the original problem: static files like css weren't being served.
+
+This version is probably sufficient for users running this only for themselves and without external access. Not being JS devs ourselves, assume it's riddled with basic issues regarding security. That said, all we did was get the docker container working with node serving the files.
+
+### NGINX
+
+NGINX is an industry-standard deployment and reverse proxy tool. It's great for serving static content, which the original project basically is. This is more robust in terms of performance, but you should still do your due diligence with regards to security.
+
+This container copies the relevant build files and just serves them as it. The `nginx.conf` is the key to getting things organized, and the data is built into the image, so no changes should occur. Updates will necessitate rebuilding the image, but that's also true for the Node Only version.
+
+

--- a/docker-compose-nodeonly.yml
+++ b/docker-compose-nodeonly.yml
@@ -1,0 +1,9 @@
+services:
+  sotn:
+    container_name: sotn-io-docker
+    build:
+      context: .
+      dockerfile: Dockerfile.nodeonly
+    image: sotn_node:v0.1
+    ports:
+      - "30000:8080"

--- a/server.js
+++ b/server.js
@@ -1,0 +1,6 @@
+var connect = require('connect');
+var serveStatic = require('serve-static');
+
+connect()
+  .use(serveStatic(__dirname))
+  .listen(8080, () => console.log('Server running on 8080...'));


### PR DESCRIPTION
found the issue: stupid typo in the `server.js` file, `server-static` -> `serve-static` (no R) ; a bad time to have mindless fingers autocomplete words in meatspace.

I pulled your changes and redid my branch so there should be no merge issues. I added docs to the readme discussing the two versions, and provided the relevant commands for each.

theoretically we could reorganize this better. LMK if you wanna discuss, or just do it if you see the obvious ways to do it.